### PR TITLE
feature: 채용 공고 수정 API

### DIFF
--- a/src/main/java/com/recruitPageProject/common/exception/CustomErrorCode.java
+++ b/src/main/java/com/recruitPageProject/common/exception/CustomErrorCode.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum CustomErrorCode {
 	//	USER_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "존재하지 않는 사용자입니다."),
-	COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 회사입니다.");
+	COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 회사입니다."),
+	JOBPOST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 채용공고입니다."),
+	NO_AUTHORIZATION(HttpStatus.UNAUTHORIZED.value(), "권한이 없습니다.");
 
 	private final int errorCode;
 	private final String errorMessage;

--- a/src/main/java/com/recruitPageProject/jobPost/controller/JobPostController.java
+++ b/src/main/java/com/recruitPageProject/jobPost/controller/JobPostController.java
@@ -1,5 +1,6 @@
 package com.recruitPageProject.jobPost.controller;
 
+import com.recruitPageProject.common.dto.ApiResponseDto;
 import com.recruitPageProject.jobPost.dto.JobPostFeedResponseDto;
 import com.recruitPageProject.jobPost.dto.JobPostRequestDto;
 import com.recruitPageProject.jobPost.service.JobPostService;
@@ -7,11 +8,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,5 +24,12 @@ public class JobPostController {
 	public ResponseEntity<JobPostFeedResponseDto> createJobPost(@Valid @RequestBody JobPostRequestDto requestDto) {
 		JobPostFeedResponseDto responseDto = jobPostService.createJobPost(requestDto);
 		return ResponseEntity.ok().body(responseDto);
+	}
+
+	@Operation(summary = "채용 공고 수정", description = "수정에 필요한 정보를 받아 채용 공고를 수정합니다")
+	@PutMapping("/jobPosts/{id}")
+	public ResponseEntity<ApiResponseDto> updateJobPost(@Valid @RequestBody JobPostRequestDto requestDto, @PathVariable Long id) {
+		jobPostService.updateJobPost(requestDto, id);
+		return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "채용 공고 수정 완료"));
 	}
 }

--- a/src/main/java/com/recruitPageProject/jobPost/entity/JobPost.java
+++ b/src/main/java/com/recruitPageProject/jobPost/entity/JobPost.java
@@ -38,4 +38,11 @@ public class JobPost extends Timestamped {
 		this.contents = requestDto.getContents();
 		this.reward = requestDto.getReward();
 	}
+
+	public void update(JobPostRequestDto requestDto) {
+		this.position = requestDto.getPosition();
+		this.skill = requestDto.getSkill();
+		this.contents = requestDto.getContents();
+		this.reward = requestDto.getReward();
+	}
 }

--- a/src/main/java/com/recruitPageProject/jobPost/service/JobPostService.java
+++ b/src/main/java/com/recruitPageProject/jobPost/service/JobPostService.java
@@ -5,8 +5,15 @@ import com.recruitPageProject.jobPost.dto.JobPostRequestDto;
 
 public interface JobPostService {
 	/**
-	 * @param requestDto(채용 공고 등록 정보)
+	 * @param requestDto (채용 공고 등록 정보)
 	 * @return JobPostFeedResponseDto (Feed에서 보여지는 채용 공고 정보)
 	 */
 	JobPostFeedResponseDto createJobPost(JobPostRequestDto requestDto);
+
+	/**
+	 *
+	 * @param requestDto (채용 공고 수정 내용)
+	 * @param id (수정할 채용 공고 id)
+	 */
+	void updateJobPost(JobPostRequestDto requestDto, Long id);
 }

--- a/src/main/java/com/recruitPageProject/jobPost/service/JobPostServiceImpl.java
+++ b/src/main/java/com/recruitPageProject/jobPost/service/JobPostServiceImpl.java
@@ -1,5 +1,7 @@
 package com.recruitPageProject.jobPost.service;
 
+import com.recruitPageProject.common.exception.CustomErrorCode;
+import com.recruitPageProject.common.exception.CustomException;
 import com.recruitPageProject.company.entity.Company;
 import com.recruitPageProject.company.service.CompanyServiceImpl;
 import com.recruitPageProject.jobPost.dto.JobPostFeedResponseDto;
@@ -24,6 +26,21 @@ public class JobPostServiceImpl implements JobPostService {
 		JobPost jobPost = new JobPost(company, requestDto);
 		jobPostRepository.save(jobPost);
 		return new JobPostFeedResponseDto(jobPost);
+	}
+
+	@Override
+	public void updateJobPost(JobPostRequestDto requestDto, Long id) {
+		Long companyId = requestDto.getCompanyId();
+		JobPost jobPost = findJobPost(id);
+		if (!jobPost.getCompany().getId().equals(companyId)) {
+			throw new CustomException(CustomErrorCode.NO_AUTHORIZATION);
+		}
+		jobPost.update(requestDto);
+	}
+
+	private JobPost findJobPost(Long id) {
+		return jobPostRepository.findById(id).orElseThrow(() ->
+				new CustomException(CustomErrorCode.JOBPOST_NOT_FOUND));
 	}
 
 }


### PR DESCRIPTION
## 관련 Issue

* #4

## 변경 사항

- [X] 채용 공고 수정 API 구현

## 포스트맨 테스트 결과

* 존재하지 않는 채용공고일 때
  * id가 3번인 채용공고는 없다.

![image](https://github.com/JisooPyo/wanted-pre-onboarding-backend/assets/130378232/9797865c-9b22-4b9b-ae0a-a769846f6f20)

* 채용공고를 쓰지 않은 다른 회사가 수정하려고 할 때
  * 1번 채용공고는 1번 회사가 썼다.

![image](https://github.com/JisooPyo/wanted-pre-onboarding-backend/assets/130378232/5e88e05c-4df2-442e-8a12-2727b0c79e10)

* 채용 공고 수정 완료
  * reward -> 1,500,000
  * contents -> '적극' 단어 추가

![image](https://github.com/JisooPyo/wanted-pre-onboarding-backend/assets/130378232/80a7f2b2-9f14-4316-af20-46545b5562c9)

* DB 반영 확인

![image](https://github.com/JisooPyo/wanted-pre-onboarding-backend/assets/130378232/0ff6e203-742f-4970-8add-bcdaaa9607c3)
