### PR TITLE
feature: 채용 공고 삭제 API

### DIFF
--- a/src/main/java/com/recruitPageProject/jobPost/controller/JobPostController.java
+++ b/src/main/java/com/recruitPageProject/jobPost/controller/JobPostController.java
@@ -1,6 +1,7 @@
 package com.recruitPageProject.jobPost.controller;
 
 import com.recruitPageProject.common.dto.ApiResponseDto;
+import com.recruitPageProject.jobPost.dto.JobPostDeleteRequestDto;
 import com.recruitPageProject.jobPost.dto.JobPostFeedResponseDto;
 import com.recruitPageProject.jobPost.dto.JobPostRequestDto;
 import com.recruitPageProject.jobPost.service.JobPostService;
@@ -27,9 +28,16 @@ public class JobPostController {
 	}
 
 	@Operation(summary = "채용 공고 수정", description = "수정에 필요한 정보를 받아 채용 공고를 수정합니다")
-	@PutMapping("/jobPosts/{id}")
+	@PutMapping("/jobPost/{id}")
 	public ResponseEntity<ApiResponseDto> updateJobPost(@Valid @RequestBody JobPostRequestDto requestDto, @PathVariable Long id) {
 		jobPostService.updateJobPost(requestDto, id);
 		return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "채용 공고 수정 완료"));
+	}
+
+	@Operation(summary = "채용 공고 삭제", description = "삭제에 필요한 정보를 받아 채용 공고를 삭제합니다")
+	@DeleteMapping("/jobPost/{id}")
+	public ResponseEntity<ApiResponseDto> deleteJobPost(@Valid @RequestBody JobPostDeleteRequestDto requestDto, @PathVariable Long id) {
+		jobPostService.deleteJobPost(requestDto, id);
+		return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "채용 공고 삭제 완료"));
 	}
 }

--- a/src/main/java/com/recruitPageProject/jobPost/dto/JobPostDeleteRequestDto.java
+++ b/src/main/java/com/recruitPageProject/jobPost/dto/JobPostDeleteRequestDto.java
@@ -1,0 +1,11 @@
+package com.recruitPageProject.jobPost.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class JobPostDeleteRequestDto {
+	@NotNull
+	Long companyId;
+}
+

--- a/src/main/java/com/recruitPageProject/jobPost/service/JobPostService.java
+++ b/src/main/java/com/recruitPageProject/jobPost/service/JobPostService.java
@@ -1,5 +1,6 @@
 package com.recruitPageProject.jobPost.service;
 
+import com.recruitPageProject.jobPost.dto.JobPostDeleteRequestDto;
 import com.recruitPageProject.jobPost.dto.JobPostFeedResponseDto;
 import com.recruitPageProject.jobPost.dto.JobPostRequestDto;
 
@@ -16,4 +17,11 @@ public interface JobPostService {
 	 * @param id (수정할 채용 공고 id)
 	 */
 	void updateJobPost(JobPostRequestDto requestDto, Long id);
+
+	/**
+	 *
+	 * @param requestDto (채용 공고 삭제 필요 정보)
+	 * @param id (삭제할 채용 공고 id)
+	 */
+	void deleteJobPost(JobPostDeleteRequestDto requestDto, Long id);
 }

--- a/src/main/java/com/recruitPageProject/jobPost/service/JobPostServiceImpl.java
+++ b/src/main/java/com/recruitPageProject/jobPost/service/JobPostServiceImpl.java
@@ -4,6 +4,7 @@ import com.recruitPageProject.common.exception.CustomErrorCode;
 import com.recruitPageProject.common.exception.CustomException;
 import com.recruitPageProject.company.entity.Company;
 import com.recruitPageProject.company.service.CompanyServiceImpl;
+import com.recruitPageProject.jobPost.dto.JobPostDeleteRequestDto;
 import com.recruitPageProject.jobPost.dto.JobPostFeedResponseDto;
 import com.recruitPageProject.jobPost.dto.JobPostRequestDto;
 import com.recruitPageProject.jobPost.entity.JobPost;
@@ -36,6 +37,16 @@ public class JobPostServiceImpl implements JobPostService {
 			throw new CustomException(CustomErrorCode.NO_AUTHORIZATION);
 		}
 		jobPost.update(requestDto);
+	}
+
+	@Override
+	public void deleteJobPost(JobPostDeleteRequestDto requestDto, Long id) {
+		Long companyId = requestDto.getCompanyId();
+		JobPost jobPost = findJobPost(id);
+		if (!jobPost.getCompany().getId().equals(companyId)) {
+			throw new CustomException(CustomErrorCode.NO_AUTHORIZATION);
+		}
+		jobPostRepository.deleteById(id);
 	}
 
 	private JobPost findJobPost(Long id) {


### PR DESCRIPTION
## 관련 Issue

* #5

## 변경 사항

- [X] 채용 공고 삭제 API 구현
- [X] 채용 공고 수정 API /jobPosts/{id} -> /jobPost/{id}로 변경

## 포스트맨 테스트

#### company_id 2인 회사가 채용공고 id 4번을 가지고 있음

![image](https://github.com/JisooPyo/wanted-pre-onboarding-backend/assets/130378232/71d205ae-b4d9-4fb9-8172-ca64df4c0863)

#### 1. 존재하지 않는 채용 공고는 삭제할 수 없다. -> 5번은 존재하지 않음

![image](https://github.com/JisooPyo/wanted-pre-onboarding-backend/assets/130378232/eaa077c0-2bc3-42bf-956b-f49376291279)

#### 2. 다른 회사의 채용공고는 삭제할 수 없다. -> 채용공고 4번을 다른 회사 1번이 삭제하려고 하면 거부됨

![image](https://github.com/JisooPyo/wanted-pre-onboarding-backend/assets/130378232/15e19b12-2283-495f-a35f-78fea17f3cec)

#### 3. 조건이 맞으면 삭제 완료 메시지 응답

![image](https://github.com/JisooPyo/wanted-pre-onboarding-backend/assets/130378232/e2516179-5830-4c0d-96f8-cfbc30d6c8f4)

#### 3-2. DB에서 지워진 것 확인

![image](https://github.com/JisooPyo/wanted-pre-onboarding-backend/assets/130378232/95a1b58a-8128-4e73-bd6a-6dbc824b0da6)
