### PR TITLE
feature: 채용 공고 상세 조회 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### QueryDsl Files ###
+**/src/main/generated/**

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,13 @@ repositories {
 }
 
 dependencies {
+    // === QueryDsl 시작 ===
+    // == 스프링 부트 3.0 이상 ==
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
@@ -38,4 +45,15 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+// Querydsl 설정
+def querydslSrcDir = 'src/main/generated'
+
+clean {
+    delete file (querydslSrcDir)
+}
+
+tasks.withType(JavaCompile) {
+    options.generatedSourceOutputDirectory = file(querydslSrcDir)
 }

--- a/src/main/java/com/recruitPageProject/common/config/QuerydslConfig.java
+++ b/src/main/java/com/recruitPageProject/common/config/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package com.recruitPageProject.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+
+}

--- a/src/main/java/com/recruitPageProject/jobPost/controller/JobPostController.java
+++ b/src/main/java/com/recruitPageProject/jobPost/controller/JobPostController.java
@@ -4,6 +4,7 @@ import com.recruitPageProject.common.dto.ApiResponseDto;
 import com.recruitPageProject.jobPost.dto.JobPostDeleteRequestDto;
 import com.recruitPageProject.jobPost.dto.JobPostFeedResponseDto;
 import com.recruitPageProject.jobPost.dto.JobPostRequestDto;
+import com.recruitPageProject.jobPost.dto.JobPostResponseDto;
 import com.recruitPageProject.jobPost.service.JobPostService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -48,5 +49,12 @@ public class JobPostController {
 	public ResponseEntity<List<JobPostFeedResponseDto>> getAllJobPosts() {
 		List<JobPostFeedResponseDto> jobPostFeedResponseDtoList = jobPostService.getAllJobPosts();
 		return ResponseEntity.ok().body(jobPostFeedResponseDtoList);
+	}
+
+	@Operation(summary = "채용 공고 상세 조회", description = "특정 채용 공고를 상세 조회합니다.")
+	@GetMapping("/jobPost/{id}")
+	public ResponseEntity<JobPostResponseDto> getJobPost(@PathVariable Long id) {
+		JobPostResponseDto responseDto = jobPostService.getJobPost(id);
+		return ResponseEntity.ok().body(responseDto);
 	}
 }

--- a/src/main/java/com/recruitPageProject/jobPost/dto/JobPostResponseDto.java
+++ b/src/main/java/com/recruitPageProject/jobPost/dto/JobPostResponseDto.java
@@ -28,4 +28,8 @@ public class JobPostResponseDto {
 		this.skill = jobPost.getSkill();
 		this.contents = jobPost.getContents();
 	}
+
+	public void addOtherJobPosts(List<Long> otherJobPosts) {
+		this.otherJobPosts = otherJobPosts;
+	}
 }

--- a/src/main/java/com/recruitPageProject/jobPost/repository/JobPostCustomRepository.java
+++ b/src/main/java/com/recruitPageProject/jobPost/repository/JobPostCustomRepository.java
@@ -1,4 +1,9 @@
 package com.recruitPageProject.jobPost.repository;
 
+import com.recruitPageProject.jobPost.entity.JobPost;
+
+import java.util.List;
+
 public interface JobPostCustomRepository {
+	List<JobPost> findOtherJobPosts(Long id);
 }

--- a/src/main/java/com/recruitPageProject/jobPost/repository/JobPostCustomRepository.java
+++ b/src/main/java/com/recruitPageProject/jobPost/repository/JobPostCustomRepository.java
@@ -1,0 +1,4 @@
+package com.recruitPageProject.jobPost.repository;
+
+public interface JobPostCustomRepository {
+}

--- a/src/main/java/com/recruitPageProject/jobPost/repository/JobPostRepository.java
+++ b/src/main/java/com/recruitPageProject/jobPost/repository/JobPostRepository.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface JobPostRepository extends JpaRepository<JobPost, Long> {
+public interface JobPostRepository extends JpaRepository<JobPost, Long>, JobPostCustomRepository {
 	List<JobPost> findAllByOrderByIdDesc();
 }

--- a/src/main/java/com/recruitPageProject/jobPost/repository/JobPostRepositoryImpl.java
+++ b/src/main/java/com/recruitPageProject/jobPost/repository/JobPostRepositoryImpl.java
@@ -1,0 +1,11 @@
+package com.recruitPageProject.jobPost.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class JobPostRepositoryImpl implements JobPostCustomRepository{
+	private final JPAQueryFactory queryFactory;
+}

--- a/src/main/java/com/recruitPageProject/jobPost/repository/JobPostRepositoryImpl.java
+++ b/src/main/java/com/recruitPageProject/jobPost/repository/JobPostRepositoryImpl.java
@@ -1,11 +1,28 @@
 package com.recruitPageProject.jobPost.repository;
 
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.recruitPageProject.jobPost.entity.JobPost;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+import static com.recruitPageProject.jobPost.entity.QJobPost.jobPost;
+
 @Repository
 @RequiredArgsConstructor
-public class JobPostRepositoryImpl implements JobPostCustomRepository{
+public class JobPostRepositoryImpl implements JobPostCustomRepository {
 	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<JobPost> findOtherJobPosts(Long id) {
+		return queryFactory.selectFrom(jobPost)
+				.where(jobPost.company.id.in(
+						JPAExpressions.select(jobPost.company.id)
+								.from(jobPost)
+								.where(jobPost.id.eq(id))
+				).and(jobPost.id.ne(id)))
+				.fetch();
+	}
 }

--- a/src/main/java/com/recruitPageProject/jobPost/service/JobPostService.java
+++ b/src/main/java/com/recruitPageProject/jobPost/service/JobPostService.java
@@ -3,6 +3,7 @@ package com.recruitPageProject.jobPost.service;
 import com.recruitPageProject.jobPost.dto.JobPostDeleteRequestDto;
 import com.recruitPageProject.jobPost.dto.JobPostFeedResponseDto;
 import com.recruitPageProject.jobPost.dto.JobPostRequestDto;
+import com.recruitPageProject.jobPost.dto.JobPostResponseDto;
 
 import java.util.List;
 
@@ -32,4 +33,11 @@ public interface JobPostService {
 	 * @return List<JobPostFeedResponseDto> (피드에서 보여지는 전체 채용 공고)
 	 */
 	List<JobPostFeedResponseDto> getAllJobPosts();
+
+	/**
+	 * 
+	 * @param id (조회하려는 채용 공고)
+	 * @return JobPostResponseDto (채용 공고 상세 정보)
+	 */
+	JobPostResponseDto getJobPost(Long id);
 }

--- a/src/main/java/com/recruitPageProject/jobPost/service/JobPostServiceImpl.java
+++ b/src/main/java/com/recruitPageProject/jobPost/service/JobPostServiceImpl.java
@@ -7,12 +7,14 @@ import com.recruitPageProject.company.service.CompanyServiceImpl;
 import com.recruitPageProject.jobPost.dto.JobPostDeleteRequestDto;
 import com.recruitPageProject.jobPost.dto.JobPostFeedResponseDto;
 import com.recruitPageProject.jobPost.dto.JobPostRequestDto;
+import com.recruitPageProject.jobPost.dto.JobPostResponseDto;
 import com.recruitPageProject.jobPost.entity.JobPost;
 import com.recruitPageProject.jobPost.repository.JobPostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -55,6 +57,19 @@ public class JobPostServiceImpl implements JobPostService {
 	public List<JobPostFeedResponseDto> getAllJobPosts() {
 		List<JobPost> jobPostList = jobPostRepository.findAllByOrderByIdDesc();
 		return jobPostList.stream().map(JobPostFeedResponseDto::new).toList();
+	}
+
+	@Override
+	public JobPostResponseDto getJobPost(Long id) {
+		JobPost jobPost = findJobPost(id);
+		JobPostResponseDto responseDto = new JobPostResponseDto(jobPost);
+		List<JobPost> otherJobPosts = jobPostRepository.findOtherJobPosts(id);
+		List<Long> otherJobPostsIdList = new ArrayList<>();
+		for(JobPost jp : otherJobPosts){
+			otherJobPostsIdList.add(jp.getId());
+		}
+		responseDto.addOtherJobPosts(otherJobPostsIdList);
+		return responseDto;
 	}
 
 	private JobPost findJobPost(Long id) {


### PR DESCRIPTION
## 관련 Issue

* #7 

## 변경 사항

- [X] QueryDsl 의존성 추가
- [X] QueryDslConfig 추가하여 Bean으로 추가
- [X] 채용 공고 상세 조회 API 구현

## 포스트맨 테스트

#### DB 확인

* id가 2인 채용 공고를 상세 조회하면 이 채용 공고를 낸 2번 회사가 낸 다른 채용 공고 5, 6, 7번의 채용 공고 리스트가 보여야 한다.

![image](https://github.com/JisooPyo/wanted-pre-onboarding-backend/assets/130378232/3f2cc6b8-26fe-41e8-a227-199a43809f5e)

####  채용 공고 상세 조회 테스트

* 채용 공고의 contents 나오는 것 확인
* 5, 6, 7번의 id list가 잘 나오는 것을 확인

![image](https://github.com/JisooPyo/wanted-pre-onboarding-backend/assets/130378232/10a80016-b827-4515-8892-5c7a18070a16)
