### PR TITLE
test: 채용공고 수정 API unit test

### DIFF
--- a/src/main/java/com/recruitPageProject/company/entity/Company.java
+++ b/src/main/java/com/recruitPageProject/company/entity/Company.java
@@ -1,11 +1,15 @@
 package com.recruitPageProject.company.entity;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 public class Company {
 	@Id

--- a/src/main/java/com/recruitPageProject/jobPost/entity/JobPost.java
+++ b/src/main/java/com/recruitPageProject/jobPost/entity/JobPost.java
@@ -4,11 +4,15 @@ import com.recruitPageProject.common.entity.Timestamped;
 import com.recruitPageProject.company.entity.Company;
 import com.recruitPageProject.jobPost.dto.JobPostRequestDto;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 public class JobPost extends Timestamped {
 	@Id

--- a/src/test/java/com/recruitPageProject/jobPost/JobPostServiceTest.java
+++ b/src/test/java/com/recruitPageProject/jobPost/JobPostServiceTest.java
@@ -1,5 +1,6 @@
 package com.recruitPageProject.jobPost;
 
+import com.recruitPageProject.common.exception.CustomException;
 import com.recruitPageProject.company.entity.Company;
 import com.recruitPageProject.company.service.CompanyServiceImpl;
 import com.recruitPageProject.jobPost.dto.JobPostFeedResponseDto;
@@ -7,37 +8,44 @@ import com.recruitPageProject.jobPost.dto.JobPostRequestDto;
 import com.recruitPageProject.jobPost.entity.JobPost;
 import com.recruitPageProject.jobPost.repository.JobPostRepository;
 import com.recruitPageProject.jobPost.service.JobPostServiceImpl;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 
+import java.util.Optional;
+
+import static com.recruitPageProject.common.exception.CustomErrorCode.JOBPOST_NOT_FOUND;
+import static com.recruitPageProject.common.exception.CustomErrorCode.NO_AUTHORIZATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @ExtendWith(MockitoExtension.class)
 public class JobPostServiceTest {
 	@Mock
 	JobPostRepository jobPostRepository;
 	@Mock
 	CompanyServiceImpl companyService;
+	@InjectMocks
+	JobPostServiceImpl jobPostService;
 	@Captor
 	private ArgumentCaptor<JobPost> jobPostCaptor;
 
 	@Test
 	@DisplayName("채용 공고 등록 테스트")
-	@Order(1)
 	void createJobPostTest() {
-		JobPostServiceImpl jobPostService = new JobPostServiceImpl(jobPostRepository, companyService);
+		// given
 		Long companyId = 100L;
 		String position = "테스트 포지션";
 		Long reward = 10000L;
 		String skill = "테스트 스킬";
 		String contents = "테스트 채용 공고";
-
 		JobPostRequestDto requestDto = JobPostRequestDto.builder()
 				.companyId(companyId)
 				.position(position)
@@ -49,8 +57,10 @@ public class JobPostServiceTest {
 		Company mockCompany = new Company();
 		when(companyService.findCompany(companyId)).thenReturn(mockCompany);
 
+		// when
 		JobPostFeedResponseDto responseDto = jobPostService.createJobPost(requestDto);
 
+		// then
 		verify(jobPostRepository, times(1)).save(jobPostCaptor.capture());
 
 		JobPost capturedJobPost = jobPostCaptor.getValue();
@@ -64,38 +74,77 @@ public class JobPostServiceTest {
 	}
 
 	@Test
-	@DisplayName("모든 채용 공고 조회 테스트")
-	@Order(2)
-	void getAllJobPostsTest() {
+	@DisplayName("채용 공고 수정 테스트 - 수정하려는 채용 공고가 없을 때")
+	void updateJobPost1() {
+		// given
+		JobPostRequestDto requestDto = JobPostRequestDto.builder().build();
 
+		when(jobPostRepository.findById(1L)).thenReturn(Optional.empty());
+
+		// when
+		CustomException exception = assertThrows(CustomException.class, () -> jobPostService.updateJobPost(requestDto, 1L));
+
+		// then
+		assertEquals(JOBPOST_NOT_FOUND, exception.getErrorCode());
+		assertEquals("존재하지 않는 채용공고입니다.", exception.getErrorCode().getErrorMessage());
+		assertEquals(HttpStatus.NOT_FOUND.value(), exception.getErrorCode().getErrorCode());
 	}
 
 	@Test
-	@DisplayName("채용 공고 상세 조회 테스트")
-	@Order(3)
-	void getJobPostTest() {
+	@DisplayName("채용 공고 수정 테스트 - 권한이 있을 때")
+	void updateJobPostTest2() {
+		// given
+		// 초기 JobPost 인스턴스 생성
+		Company company = Company.builder().id(100L).build();
+		JobPost jobPost = JobPost.builder()
+				.id(37L).company(company).position("테스트 포지션")
+				.reward(1_500_000L).skill("테스트 스킬")
+				.contents("테스트 채용 공고 내용").build();
 
+		// 수정 필요 정보 JobPostRequestDto
+		JobPostRequestDto requestDto = JobPostRequestDto.builder()
+				.companyId(100L)
+				.position("테스트 포지션 2").reward(2_000_000L)
+				.skill("테스트 스킬 2").contents("테스트 채용 공고 내용 2").build();
+
+		when(jobPostRepository.findById(37L)).thenReturn(Optional.of(jobPost));
+
+		// when
+		jobPostService.updateJobPost(requestDto, 37L);
+
+		// then
+		assertEquals("테스트 포지션 2", jobPost.getPosition());
+		assertEquals(2_000_000L, jobPost.getReward());
+		assertEquals("테스트 스킬 2", jobPost.getSkill());
+		assertEquals("테스트 채용 공고 내용 2", jobPost.getContents());
 	}
 
 	@Test
-	@DisplayName("채용 공고 검색 테스트")
-	@Order(4)
-	void searchJobPostsTest() {
+	@DisplayName("채용 공고 수정 테스트 - 권한이 없을 때")
+	void updateJobPostTest3() {
+		// given
+		// 초기 JobPost 인스턴스 생성
+		Company company = Company.builder().id(100L).build();
+		JobPost jobPost = JobPost.builder()
+				.id(37L).company(company).position("테스트 포지션")
+				.reward(1_500_000L).skill("테스트 스킬")
+				.contents("테스트 채용 공고 내용").build();
 
-	}
+		// 수정 필요 정보 : 100번 회사의 채용공고를 50번 회사가 고치려고 시도
+		JobPostRequestDto requestDto = JobPostRequestDto.builder()
+				.companyId(50L)
+				.position("테스트 포지션 2").reward(2_000_000L)
+				.skill("테스트 스킬 2").contents("테스트 채용 공고 내용 2").build();
 
-	@Test
-	@DisplayName("채용 공고 수정 테스트")
-	@Order(5)
-	void updateJobPostTest() {
+		when(jobPostRepository.findById(37L)).thenReturn(Optional.of(jobPost));
 
-	}
+		// when
+		CustomException exception = assertThrows(CustomException.class, () -> jobPostService.updateJobPost(requestDto, 37L));
 
-	@Test
-	@DisplayName("채용 공고 삭제 테스트")
-	@Order(6)
-	void deleteJobPostTest() {
+		// then
+		assertEquals(NO_AUTHORIZATION, exception.getErrorCode());
+		assertEquals("권한이 없습니다.", exception.getErrorCode().getErrorMessage());
+		assertEquals(HttpStatus.UNAUTHORIZED.value(), exception.getErrorCode().getErrorCode());
 
 	}
 }
-


### PR DESCRIPTION
## 관련 Issue

* #30 

## 변경 사항

* 채용공고 수정 API unit test
- [x] 수정하려는 채용공고가 없을 때
- [x] 다른 회사가 채용공고를 수정하려고 할 때
- [x] 자기 회사의 채용공고를 수정하려고 할 때

## 테스트 결과

![image](https://github.com/JisooPyo/wanted-pre-onboarding-backend/assets/130378232/f9ab8aff-5231-4d94-9c20-bad14ceecf85)
